### PR TITLE
修复mapvLayer在浏览器缩放时元素位置不正确问题

### DIFF
--- a/src/mapboxgl/overlay/MapvLayer.js
+++ b/src/mapboxgl/overlay/MapvLayer.js
@@ -117,15 +117,15 @@ export class MapvLayer {
         canvas.style.position = 'absolute';
         canvas.style.top = 0 + "px";
         canvas.style.left = 0 + "px";
-        canvas.width = parseInt(this.map.getCanvas().style.width);
-        canvas.height = parseInt(this.map.getCanvas().style.height);
-        canvas.style.width = this.map.getCanvas().style.width;
-        canvas.style.height = this.map.getCanvas().style.height;
         var global$2 = typeof window === 'undefined' ? {} : window;
         var devicePixelRatio = this.devicePixelRatio = global$2.devicePixelRatio;
+        canvas.width = parseInt(this.map.getCanvas().style.width)*devicePixelRatio;
+        canvas.height = parseInt(this.map.getCanvas().style.height)*devicePixelRatio;
         if (this.mapVOptions.context == '2d') {
             canvas.getContext(this.mapVOptions.context).scale(devicePixelRatio, devicePixelRatio);
         }
+        canvas.style.width = this.map.getCanvas().style.width;
+        canvas.style.height = this.map.getCanvas().style.height;
         return canvas;
     }
 

--- a/src/mapboxgl/overlay/mapv/MapvRenderer.js
+++ b/src/mapboxgl/overlay/mapv/MapvRenderer.js
@@ -308,8 +308,11 @@ export class MapvRenderer extends BaseLayer {
         canvas.style.position = 'absolute';
         canvas.style.top = 0 + "px";
         canvas.style.left = 0 + "px";
-        canvas.width = parseInt(this.map.getCanvas().style.width);
-        canvas.height = parseInt(this.map.getCanvas().style.height);
+        var global$2 = typeof window === 'undefined' ? {} : window;
+        var devicePixelRatio = this.canvasLayer.devicePixelRatio = global$2.devicePixelRatio;
+        canvas.width = parseInt(this.map.getCanvas().style.width)*devicePixelRatio;
+        canvas.height = parseInt(this.map.getCanvas().style.height)*devicePixelRatio;
+
         canvas.style.width = this.map.getCanvas().style.width;
         canvas.style.height = this.map.getCanvas().style.height;
     }


### PR DESCRIPTION
1、修复mapvLayer在浏览器缩放时元素位置偏移问题
2、修复缩放时左右拖动地图部分元素未清除问题
3、修复在浏览器窗口不是100%情况下缩放，点击事件和鼠标事件获取不到元素问题