### PR TITLE
KVP转义问题

### DIFF
--- a/src/leaflet/mapping/TileLayer.WMTS.js
+++ b/src/leaflet/mapping/TileLayer.WMTS.js
@@ -93,7 +93,11 @@ export var WMTSLayer = L.TileLayer.extend({
         }
 
         if (this.options.requestEncoding === 'KVP') {
-            url += L.Util.getParamString(obj, url);
+           var params = [];
+            for (var i in obj) {
+                params.push(i + '=' + obj[i]);
+            }
+            url += "?"+params.join('&');
         } else if (this.options.requestEncoding === 'REST') {
             var params = "/" + obj.layer + "/" + obj.style + "/" + obj.tilematrixSet + "/" + obj.tilematrix + "/" + obj.tilerow + "/" + obj.tilecol + this.formatSuffix;
             url += params;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/23150744/57844795-52bf1400-7803-11e9-9cba-66a494798f92.png)


format=image/png被转义为
format=image%2Fpng
导致有些要求严格的server参数错误，iServer本身没有问题