### PR TITLE
[bug] 在https网站的时候, key/token 使用失效

### DIFF
--- a/src/common/security/SecurityManager.js
+++ b/src/common/security/SecurityManager.js
@@ -351,7 +351,8 @@ export class SecurityManager {
         if (!url) {
             return url;
         }
-        var patten = /http:\/\/(.*\/rest)/i;
+        // var patten = /http:\/\/(.*\/rest)/i;
+        var patten = /(http|https):\/\/(.*\/rest)/i;
         var result = url.match(patten);
         if (!result) {
             return url;


### PR DESCRIPTION
正则 缺少对https的匹配，导致在https网站的时候, key/token 使用失效